### PR TITLE
Update old link to lines-areas-labels.stylx

### DIFF
--- a/data/mil2525d/utilities/style-utilities/merge-stylx-utilities/Readme.md
+++ b/data/mil2525d/utilities/style-utilities/merge-stylx-utilities/Readme.md
@@ -4,7 +4,7 @@
 
 * Merges:
     * A version of the .stylx that is edited and maintained in ArcGIS Pro
-    * See: [mil2525d-lines-areas-labels-base-template.stylx](https://github.com/ArcGIS/military-features-pro-data/blob/master/data/core_data/stylxfiles/mil2525d-lines-areas-labels-base-template.stylx)
+    * See: [mil2525d-lines-areas-labels-base-template.stylx](../../../core_data/stylxfiles/mil2525d-lines-areas-labels-base-template.stylx)
 * -with-
     * A version of the .stylx file with the SVG/EMF marker/points-only icons. This version is normally automatically generated from SVG icon marker symbols and meta-data-tagged source data from the [joint-military-symbology-xml repository](https://github.com/Esri/joint-military-symbology-xml)
     * For more information on this data/process/version, see :


### PR DESCRIPTION
Chris, the link to the 'lines-areas-labels-base-template.stylx' navigated to a "retired-dont-use" section of the repo, with a version of the .stylx from November 2014. You can see that I changed the path of this folder to an updated version of the template stylx, located in "core data/stylx files." Later on in the readme (line 23) the proper location of 'lines-areas-labels-base-template.stylx' is mentioned anyway.