### PR TITLE
Readme Update for renamed style file

### DIFF
--- a/data/mil2525d/utilities/style-utilities/README.md
+++ b/data/mil2525d/utilities/style-utilities/README.md
@@ -74,8 +74,7 @@
     * Close ArcMap
     * Once you have verified/validated the output style files, you may want to rename them
     * Note: names *without spaces* were used during the conversion process so you may wish to change these names at this time (if you updating the .styles in this repo)
-* Create a Pro .stylx file for the ["All Icons" style file - "Military 2525Delta All.style"](../../core_data/stylefiles/Military%202525Delta%20All.style)
-    * **Rename** the style file created that contains with all the icons `Military 2525Delta All Icons.style` to `mil2525d-points-only.style`
+* Create a Pro .stylx file for ["mil2525d-points-only.style"](../../core_data/stylefiles/Military%202525Delta%20All.style)
     * Open ArcGIS Pro and import the file `mil2525d-points-only.style` 
         * Project | Styles | Import Style - *(Note this operation may take several minutes to complete)*
     * Verify/validate that the file imported correctly and the icons look as expected


### PR DESCRIPTION
I'm making these edits to reflect that the style file that gets converted to .stylx is called mil2525d-points-only.style. I think the link can't be updated until you merge my PR #156 where I actually changed the name/deleted the excess style files, so that's one remaining edit that I can do tomorrow. Just verify that these instructions make sense and I'm correct in where I replaced the style name.